### PR TITLE
More flexible metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# version: ashedpotatoes/usher-plus:0.6.6_rev12
+# version: ashedpotatoes/usher-plus:0.6.6_rev13
 
 # Hardcoded-for-reproducibility stuff you may eventually want to update:
 # * UShER v0.6.6

--- a/data/FAKE_sample_metadata.tsv
+++ b/data/FAKE_sample_metadata.tsv
@@ -1,22 +1,22 @@
-sample_id	Year_Collected	Patient_County	State	Epi_Duplication	Country	Latitude	Longitude	Submitter_Facility	Submitter_Facility_Sample_ID	Sequencing_Facility	Notes
-FAKE_DATA_1	2020	Santa Cruz	CA					Santa Cruz CHD		Propane and Genomic Sequencing LLC	
-FAKE_DATA_2	2021	Los Angeles	CA					LA CHD		Propane and Genomic Sequencing LLC	
-FAKE_DATA_3	2022	Mendocino	CA					Mendocino Department of Health		Propane and Genomic Sequencing LLC	Actual name on diff is "FAKE_DATA_3_AMBIGUOUS" so this tests the sample-renamed edge case
-FAKE_DATA_4	2022	Mendocino	CA					Mendocino Department of Health		Propane and Genomic Sequencing LLC	
-FAKE_DATA_5	2022		CA							Propane and Genomic Sequencing LLC	
-FAKE_DATA_6	2022	Mendocino	CA					Mendocino Department of Health		Propane and Genomic Sequencing LLC	
-FAKE_DATA_7	2022	Santa Cruz	CA		USA			Surfer's Union	x23cw24	Seaside Company Sequencing
-FAKE_DATA_8	2022	San Francisco	CA		USA			Sutter Health SF	x24ev09	Sutter Health SF
-L7_N3913_borrell	2023									Propane and Genomic Sequencing LLC	
-L4.1_samp4	2015	Alameda	CA							Propane and Genomic Sequencing LLC	
-L4.1_samp5	1800	Alameda	CA							Propane and Genomic Sequencing LLC	
-multistrain_pass_10	1905	Alameda								Propane and Genomic Sequencing LLC	
-multistrain_pass_11	2020	Napa	CA							Propane and Genomic Sequencing LLC	
-C_ZONE_1										Propane and Genomic Sequencing LLC	
-C_ZONE_2				true						Propane and Genomic Sequencing LLC	
-C_ZONE_3										Propane and Genomic Sequencing LLC	
-C_ZONE_4										Propane and Genomic Sequencing LLC	
-Identical_Cats_1	2020	Mendocino	CA		USA			Mendocino CHD	0000CD1	Bob's Budget HiSeq	
-Identical_Cats_2	2021	Mendocino	CA		USA			Mendocino CHD	0000CD2	Bob's Budget HiSeq	
-Identical_Cats_3	2020	Salt Lake	UT		USA			Mendocino CHD	0000CD4	Bob's Budget HiSeq	
-Identical_Cats_4	2025	Mendocino	CA		USA			Mendocino CHD	0000CD9	Bob's Budget HiSeq	
+sample_id	Year_Collected	Patient_County	State	Epi_Duplication	Country	Latitude	Longitude	Submitter_Facility	Submitter_Facility_Sample_ID	Sequencing_Facility	Notes	tbd_strain_per_tbprof	tbd_resistance
+FAKE_DATA_1	2020	Santa Cruz	CA					Santa Cruz CHD		Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+FAKE_DATA_2	2021	Los Angeles	CA					LA CHD		Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+FAKE_DATA_3	2022	Mendocino	CA					Mendocino Department of Health		Propane and Genomic Sequencing LLC	Actual name on diff is "FAKE_DATA_3_AMBIGUOUS" so this tests the sample-renamed edge case	Lineage1	Sensitive
+FAKE_DATA_4	2022	Mendocino	CA					Mendocino Department of Health		Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+FAKE_DATA_5	2022		CA							Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+FAKE_DATA_6	2022	Mendocino	CA					Mendocino Department of Health		Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+FAKE_DATA_7	2022	Santa Cruz	CA		USA			Surfer's Union	x23cw24	Seaside Company Sequencing		La1.3	Sensitive
+FAKE_DATA_8	2022	San Francisco	CA		USA			Sutter Health SF	x24ev09	Sutter Health SF		Lineage1	Sensitive
+L7_N3913_borrell	2023									Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+L4.1_samp4	2015	Alameda	CA							Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+L4.1_samp5	1800	Alameda	CA							Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+multistrain_pass_10	1905	Alameda								Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+multistrain_pass_11	2020	Napa	CA							Propane and Genomic Sequencing LLC		Lineage1	Sensitive
+C_ZONE_1										Propane and Genomic Sequencing LLC		La1.2	Sensitive
+C_ZONE_2				true						Propane and Genomic Sequencing LLC		La1	Sensitive
+C_ZONE_3										Propane and Genomic Sequencing LLC		La1.2.BCG	Sensitive
+C_ZONE_4										Propane and Genomic Sequencing LLC		La1.2.BCG	Sensitive
+Identical_Cats_1	2020	Mendocino	CA		USA			Mendocino CHD	0000CD1	Bob's Budget HiSeq		La2	Sensitive
+Identical_Cats_2	2021	Mendocino	CA		USA			Mendocino CHD	0000CD2	Bob's Budget HiSeq		La2	Sensitive
+Identical_Cats_3	2020	Salt Lake	UT		USA			Mendocino CHD	0000CD4	Bob's Budget HiSeq		La2	Sensitive
+Identical_Cats_4	2025	Mendocino	CA		USA			Mendocino CHD	0000CD9	Bob's Budget HiSeq		La2	Sensitive

--- a/input_jsons/tree_nine_test_clustering.json
+++ b/input_jsons/tree_nine_test_clustering.json
@@ -28,7 +28,6 @@
   "Tree_Nine.matOptimize_usher.max_iterations": 5,
   "Tree_Nine.process_clusters.verbose": true,
   "Tree_Nine.process_clusters.no_dropped_sample_failsafe": true,
-  "Tree_Nine.cluster.no_dropped_sample_failsafe": true,
   "Tree_Nine.identify_clusters": true,
   "Tree_Nine.cluster_entire_tree": true,
   "Tree_Nine.persistent_cluster_meta": "./data/FAKE_persistent_cluster_meta_no_MR_IDs.tsv",
@@ -41,6 +40,6 @@
   "Tree_Nine.process_clusters.override_find_clusters_script": "/Users/aofarrel/github/tree_nine/find_clusters.py",
   "Tree_Nine.process_clusters.override_process_clusters_script": "/Users/aofarrel/github/tree_nine/process_clusters.py",
   "Tree_Nine.process_clusters.override_mass_rename_script": "/Users/aofarrel/github/tree_nine/mass_rename_to_persistent_id.py",
-  "Tree_Nine.upload_clusters_to_microreact": true,
+  "Tree_Nine.upload_clusters_to_microreact": false,
   "Tree_Nine.microreact_key": "../../Downloads/TOKEN_MR_MINE",
 }

--- a/input_jsons/tree_nine_test_clustering.json
+++ b/input_jsons/tree_nine_test_clustering.json
@@ -30,7 +30,7 @@
   "Tree_Nine.process_clusters.no_dropped_sample_failsafe": true,
   "Tree_Nine.identify_clusters": true,
   "Tree_Nine.cluster_entire_tree": true,
-  "Tree_Nine.persistent_cluster_meta": "./data/FAKE_persistent_cluster_meta_no_MR_IDs.tsv",
+  "Tree_Nine.persistent_cluster_meta": "./data/FAKE_persistent_cluster_meta.tsv",
   "Tree_Nine.persistent_cluster_ids": "./data/FAKE_persistent_ids.tsv",
   "Tree_Nine.sample_metadata_tsv": "./data/FAKE_sample_metadata.tsv",
   "Tree_Nine.microreact_blank_template_json": "/Users/aofarrel/github/YARGH/mr/BLANK_template.json",
@@ -40,6 +40,6 @@
   "Tree_Nine.process_clusters.override_find_clusters_script": "/Users/aofarrel/github/tree_nine/find_clusters.py",
   "Tree_Nine.process_clusters.override_process_clusters_script": "/Users/aofarrel/github/tree_nine/process_clusters.py",
   "Tree_Nine.process_clusters.override_mass_rename_script": "/Users/aofarrel/github/tree_nine/mass_rename_to_persistent_id.py",
-  "Tree_Nine.upload_clusters_to_microreact": false,
+  "Tree_Nine.upload_clusters_to_microreact": true,
   "Tree_Nine.microreact_key": "../../Downloads/TOKEN_MR_MINE",
 }

--- a/mass_rename_to_persistent_id.py
+++ b/mass_rename_to_persistent_id.py
@@ -1,4 +1,13 @@
-# pylint: disable=trailing-whitespace,line-too-long,missing-module-docstring,consider-using-tuple,missing-function-docstring,broad-exception-caught
+"""
+Mass rename nwks, distance matrices, and pbs from their latest (workdir) cluster IDs to their persistent IDs. We
+need to do this because find_clusters.py generates clusters (and many outputs) ignorant of their persistent IDs. 
+Previously we didn't bother since Microreact is the source-of-truth, but it makes sense to have better backups
+that wouldn't need to be "translated" to actually be useful.
+"""
+VERSION="0.0.2"
+
+# pylint: disable=trailing-whitespace,line-too-long,consider-using-tuple,useless-suppression
+# pylint: disable=missing-function-docstring,broad-exception-caught,wrong-import-position
 import json
 import sys
 from pathlib import Path
@@ -18,11 +27,12 @@ def rename_file(workdir_id, cluster_id, extension):
             return f"{old_filename} -> {new_filename}"
         except Exception as e:
             return f"Error renaming {old_filename} to {new_filename}: {e}"
-    return f"Skip: {old_filename} not found."
+    return f"Skipped: {old_filename} not found, not converting to {new_filename} (likely a decimated cluster)"
 
 def main():
     parser = argparse.ArgumentParser(description="Mass rename files from find_clusters.py into their persistent ID names post process_clusters.py")
-    parser.add_argument('-json', type=str, required=False, help="path to all_cluster_information JSON")
+    parser.add_argument('--json', type=str, required=False, help="path to all_cluster_information JSON")
+    parser.add_argument('--verbose', action='store_true', help="print all renames (recommended unless your logger is extremely slow)")
     args = parser.parse_args()
 
     id_map = {} # {workdir_cluster_id: cluster_id}
@@ -31,7 +41,18 @@ def main():
         for line in f:
             if line.strip():
                 data = json.loads(line)
-                id_map[data['workdir_cluster_id']] = data['cluster_id']
+
+                # check for error cases
+                if data["decimated"] is True and data["workdir_cluster_id"] is not None:
+                    raise ValueError(f"Found decimated cluster with a workdir ID: {data}")
+                if data["workdir_cluster_id"] is None and data["decimated"] is not True:
+                    raise ValueError(f"Found null workdir_cluster_id in non-decimated cluster: {data}")
+                
+                # handle normal decimation case (wouldn't cause error if we didn't do this but good practice)
+                if data["decimated"] is True and data["workdir_cluster_id"] is None:
+                    print(f"Will skip decimated cluster with null workdir_cluster_id and persistent cluster_id {data['cluster_id']}")
+                else:
+                    id_map[data['workdir_cluster_id']] = data['cluster_id']
 
     print(f"Loaded {len(id_map)} mappings. Starting renaming...", file=sys.stderr)
 

--- a/matutils_and_friends.wdl
+++ b/matutils_and_friends.wdl
@@ -38,7 +38,7 @@ task extract {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -68,7 +68,7 @@ task mask {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -103,7 +103,7 @@ task reroot {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -163,7 +163,7 @@ task summarize {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -200,7 +200,7 @@ task annotate {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -274,7 +274,7 @@ task convert_to_newick_subtrees_by_cluster {
 		bootDiskSizeGb: 15
 		cpu: 12
 		disks: "local-disk " + 150 + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: 1
 	}
@@ -342,7 +342,7 @@ task convert_to_nextstrain_subtrees_by_cluster {
 		bootDiskSizeGb: 15
 		cpu: 12
 		disks: "local-disk " + 150 + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: 1
 	}
@@ -397,7 +397,7 @@ task convert_to_nextstrain_subtrees {
 		bootDiskSizeGb: 15
 		cpu: 12
 		disks: "local-disk " + 150 + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: 1
 	}
@@ -426,7 +426,7 @@ task convert_to_nextstrain_single {
 		bootDiskSizeGb: 15
 		cpu: 12
 		disks: "local-disk " + 150 + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: 1
 	}
@@ -457,7 +457,7 @@ task convert_to_nextstrain_single_terra_compatiable {
 		bootDiskSizeGb: 15
 		cpu: 12
 		disks: "local-disk " + 150 + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: 1
 	}
@@ -481,7 +481,7 @@ task convert_to_newick {
 		bootDiskSizeGb: 15
 		cpu: 8
 		disks: "local-disk " + 100 + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: 8 + " GB"
 		preemptible: 1
 	}
@@ -571,7 +571,7 @@ task usher_sampled_diff {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -615,7 +615,7 @@ task matOptimize {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -649,7 +649,7 @@ task convert_to_taxonium {
 	runtime {
 		cpu: cpu
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}
@@ -1114,7 +1114,7 @@ task cluster_CDPH_method {
 		bootDiskSizeGb: 15
 		cpu: 12
 		disks: "local-disk " + 150 + " SSD"
-		docker: "ashedpotatoes/usher-plus:0.6.6_rev12"
+		docker: "ashedpotatoes/usher-plus:0.6.6_rev13"
 		memory: memory + " GB"
 		preemptible: preempt
 	}

--- a/process_clusters.py
+++ b/process_clusters.py
@@ -1,4 +1,4 @@
-VERSION = "0.5.4" # does not necessarily match Tree Nine git version
+VERSION = "0.5.5" # does not necessarily match Tree Nine git version
 print(f"PROCESS CLUSTERS - VERSION {VERSION}")
 
 # TODO: 
@@ -91,7 +91,6 @@ def main():
     parser.add_argument('-pcm', '--persistentclustermeta', type=str, help='TSV: persistent cluster metadata from last full run of TB-D')
     parser.add_argument('-pid', '--persistentids', type=str, help='TSV: persistent IDs from last full run of TB-D')
     parser.add_argument('-mat', '--mat_tree', type=str, help='PB: tree')
-    #parser.add_argument('-cs', '--contextsamples', type=int, default=0, help="[UNUSED] int: Number of context samples for cluster subtrees")
     parser.add_argument('-cd', '--combineddiff', type=str, help='diff: Maple-formatted combined diff file, needed for backmasking')
     parser.add_argument('-dl', '--denylist', type=str, required=False, help='TXT: newline delimited list of cluster IDs to never use')
     parser.add_argument('-mr', '--upload_to_microreact', action='store_true', help='upload clusters to MR (requires -to)')
@@ -1398,6 +1397,17 @@ def main():
         debug_logging_handler_txt("Deleted input persistentclustermeta, input persistentids, and input token", "11_finish", 10)
     all_cluster_information.write_ndjson(f'all_cluster_information{today.isoformat()}.json')
     debug_logging_handler_txt(f"Wrote all_cluster_information{today.isoformat()}.json", "11_finish", 20)
+
+    decimated_clusters = all_cluster_information.filter(pl.col("decimated")).select(["cluster_id", "workdir_cluster_id", "decimated", "newly_decimated", "sample_id", "sample_id_previously"])
+    debug_logging_handler_df("Decimated clusters", decimated_clusters, "11_finish")
+    try:
+        decimated_clusters.write_csv(f'decimated{today.isoformat()}.tsv', separator='\t')
+        debug_logging_handler_txt(f"Wrote decimated{today.isoformat()}.tsv", "11_finish", 20)
+    except pl.ComputeError as e:
+        # some versions of polars complain if you try to write a TSV with a list column
+        decimated_clusters = decimated_clusters.select(["cluster_id"])
+        decimated_clusters.write_csv(f'decimated{today.isoformat()}.tsv', separator='\t')
+        debug_logging_handler_txt(f"Wrote cluster-id only version of decimated{today.isoformat()}.tsv due to pl.ComputeError: {e}", "11_finish", 30)
     
     # persistentMETA and persistentIDS are needed for subsequent runs
     new_persistent_meta.write_csv(f'persistentMETA{today.isoformat()}.tsv', separator='\t')
@@ -1407,13 +1417,24 @@ def main():
     debug_logging_handler_txt(f"Wrote persistentIDS{today.isoformat()}.tsv", "11_finish", 20)
 
     # the sample \t cluster TSVs can be used to convert to annotated nextstrain format
+    # for some reasons polars doesn't seem to complain about these list columns, but in case it ever does, we'll try block this
     samp_persistent20cluster = new_persistent_ids.filter(pl.col('cluster_distance') == 20).select(['sample_id', 'cluster_id'])
     samp_persistent10cluster = new_persistent_ids.filter(pl.col('cluster_distance') == 10).select(['sample_id', 'cluster_id'])
     samp_persistent5cluster = new_persistent_ids.filter(pl.col('cluster_distance') == 5).select(['sample_id', 'cluster_id'])
-    samp_persistent20cluster.write_csv(f'samp_persis20cluster{today.isoformat()}.tsv', separator='\t')
-    samp_persistent10cluster.write_csv(f'samp_persis10cluster{today.isoformat()}.tsv', separator='\t')
-    samp_persistent5cluster.write_csv(f'samp_persis5cluster{today.isoformat()}.tsv', separator='\t')
-    debug_logging_handler_txt(f"Wrote samp_persis20cluster{today.isoformat()}.tsv, samp_persis10cluster{today.isoformat()}.tsv, and samp_persis5cluster{today.isoformat()}.tsv", "11_finish", 20)
+    try:
+        samp_persistent20cluster.write_csv(f'samp_persis20cluster{today.isoformat()}.tsv', separator='\t')
+        samp_persistent10cluster.write_csv(f'samp_persis10cluster{today.isoformat()}.tsv', separator='\t')
+        samp_persistent5cluster.write_csv(f'samp_persis5cluster{today.isoformat()}.tsv', separator='\t')
+        debug_logging_handler_txt(f"Wrote samp_persis20cluster{today.isoformat()}.tsv, samp_persis10cluster{today.isoformat()}.tsv, and samp_persis5cluster{today.isoformat()}.tsv", "11_finish", 20)
+    except pl.ComputeError as e:
+        # untested extremely goofy workaround
+        samp_persistent20cluster = samp_persistent20cluster.with_columns("[" + pl.col("sample_id").cast(pl.List(pl.String)).list.join(",") + "]").drop("sample_id")
+        samp_persistent10cluster = samp_persistent10cluster.with_columns("[" + pl.col("sample_id").cast(pl.List(pl.String)).list.join(",") + "]").drop("sample_id")
+        samp_persistent5cluster = samp_persistent5cluster.with_columns("[" + pl.col("sample_id").cast(pl.List(pl.String)).list.join(",") + "]").drop("sample_id")
+        samp_persistent20cluster.write_csv(f'samp_persis20cluster{today.isoformat()}.tsv', separator='\t')
+        samp_persistent10cluster.write_csv(f'samp_persis10cluster{today.isoformat()}.tsv', separator='\t')
+        samp_persistent5cluster.write_csv(f'samp_persis5cluster{today.isoformat()}.tsv', separator='\t')
+        debug_logging_handler_txt(f"Wrote stringafied versions of sample_persis*.tsv due to pl.ComputeError: {e}, column names may be incorrect", "11_finish", 30)
     
     change_report = []
     debug_logging_handler_txt("Building change report...", "11_finish", 20)

--- a/process_clusters.py
+++ b/process_clusters.py
@@ -1,4 +1,4 @@
-VERSION = "0.5.6" # does not necessarily match Tree Nine git version
+VERSION = "0.6.0" # does not necessarily match Tree Nine git version
 print(f"PROCESS CLUSTERS - VERSION {VERSION}")
 
 # TODO: 
@@ -1946,9 +1946,9 @@ def set_microreact_metadata(mr_document: dict, row: dict, desired_mr_metadata_co
 
     # this needs to be set properly or else metadata fields aren't actually visible
     metadata_columns = []
-    for key in metadata_dicts: # this DOES include "id" column
+    for key in metadata_dicts[0].keys(): # this DOES include "id" column
         metadata_columns.append({"field": key, "fixed": False})
-    mr_document["tables"]["columns"] = metadata_columns
+    mr_document["tables"]["table-1"]["columns"] = metadata_columns
     return mr_document
 
 def share_mr_project(token, mr_url, email, retries=-1): # returns None

--- a/process_clusters.py
+++ b/process_clusters.py
@@ -1,4 +1,4 @@
-VERSION = "0.5.5" # does not necessarily match Tree Nine git version
+VERSION = "0.5.6" # does not necessarily match Tree Nine git version
 print(f"PROCESS CLUSTERS - VERSION {VERSION}")
 
 # TODO: 
@@ -55,6 +55,7 @@ import requests
 import polars as pl
 import polars.selectors as cs
 from polars.testing import assert_series_equal
+from polars.exceptions import ComputeError
 pl.Config.set_tbl_rows(-1)
 pl.Config.set_tbl_cols(-1)
 pl.Config.set_tbl_width_chars(200)
@@ -1403,7 +1404,7 @@ def main():
     try:
         decimated_clusters.write_csv(f'decimated{today.isoformat()}.tsv', separator='\t')
         debug_logging_handler_txt(f"Wrote decimated{today.isoformat()}.tsv", "11_finish", 20)
-    except pl.ComputeError as e:
+    except ComputeError as e:
         # some versions of polars complain if you try to write a TSV with a list column
         decimated_clusters = decimated_clusters.select(["cluster_id"])
         decimated_clusters.write_csv(f'decimated{today.isoformat()}.tsv', separator='\t')
@@ -1426,7 +1427,7 @@ def main():
         samp_persistent10cluster.write_csv(f'samp_persis10cluster{today.isoformat()}.tsv', separator='\t')
         samp_persistent5cluster.write_csv(f'samp_persis5cluster{today.isoformat()}.tsv', separator='\t')
         debug_logging_handler_txt(f"Wrote samp_persis20cluster{today.isoformat()}.tsv, samp_persis10cluster{today.isoformat()}.tsv, and samp_persis5cluster{today.isoformat()}.tsv", "11_finish", 20)
-    except pl.ComputeError as e:
+    except ComputeError as e:
         # untested extremely goofy workaround
         samp_persistent20cluster = samp_persistent20cluster.with_columns("[" + pl.col("sample_id").cast(pl.List(pl.String)).list.join(",") + "]").drop("sample_id")
         samp_persistent10cluster = samp_persistent10cluster.with_columns("[" + pl.col("sample_id").cast(pl.List(pl.String)).list.join(",") + "]").drop("sample_id")

--- a/process_clusters.py
+++ b/process_clusters.py
@@ -1,4 +1,4 @@
-VERSION = "0.5.3" # does not necessarily match Tree Nine git version
+VERSION = "0.5.4" # does not necessarily match Tree Nine git version
 print(f"PROCESS CLUSTERS - VERSION {VERSION}")
 
 # TODO: 
@@ -141,7 +141,7 @@ def main():
     if args.samplemeta:
         all_samples_metadata = pl.read_csv(args.samplemeta, separator="\t")
         
-        # fallback for Terra data tables
+        # fallback for Terra data tables (going forward we will run a task upstream that handles this but good check to keep)
         entity_id_columns = [
             col for col in all_samples_metadata.columns 
             if col.startswith("entity:") and col.endswith("_id")
@@ -1915,6 +1915,18 @@ def set_microreact_metadata(mr_document: dict, row: dict, desired_mr_metadata_co
     labels = output.getvalue()
     mr_document["files"]["ji0o"]["name"] = f"{row['cluster_id']}_metadata.csv"
     mr_document["files"]["ji0o"]["blob"] = labels
+
+    # if this is set to a metadata value that doesn't exist, that's okay, but ideally we'd set it to county
+    if 'Patient_County' in desired_mr_metadata_columns:
+        mr_document["styles"]["coloursField"] = "Patient_County"
+    else:
+        mr_document["styles"]["coloursField"] = desired_mr_metadata_columns[0] # already asserted it's not 'id'
+
+    # this needs to be set properly or else metadata fields aren't actually visible
+    metadata_columns = []
+    for key in metadata_dicts: # this DOES include "id" column
+        metadata_columns.append({"field": key, "fixed": False})
+    mr_document["tables"]["columns"] = metadata_columns
     return mr_document
 
 def share_mr_project(token, mr_url, email, retries=-1): # returns None

--- a/split_cluster_tasks.wdl
+++ b/split_cluster_tasks.wdl
@@ -463,7 +463,7 @@ task process_CDPH_clusters {
 		fi
 
 		echo "[$(date '+%Y-%m-%d %H:%M:%S')] Running mass_rename_to_persistent_id.py"
-		python3 /HOME/ash/scripts/mass_rename_to_persistent_id.py -json "all_cluster_information~{datestamp}.json"
+		python3 /HOME/ash/scripts/mass_rename_to_persistent_id.py "~{arg_verbose}" --json "all_cluster_information~{datestamp}.json"
 		echo "[$(date '+%Y-%m-%d %H:%M:%S')] Finished mass_rename_to_persistent_id.py"
 
 		echo "The IDs of these clusters were processed by process_clusters.py on ~{datestamp}(ish) and DO account for persistent cluster IDs. " > readme.txt
@@ -510,6 +510,7 @@ task process_CDPH_clusters {
 		# stats for the nerds, currently unused downstream
 		File new_samples_cluster_information = "new_samples" + datestamp + ".tsv"
 		File all_samples_cluster_information = "all_samples" + datestamp + ".tsv"
+		File? decimated_clusters = "decimated" + datestamp + ".tsv"
 		File? updated_mr_URIs_file = "updated_mr_URIs" + datestamp + ".txt"
 
 		# debug

--- a/split_cluster_tasks.wdl
+++ b/split_cluster_tasks.wdl
@@ -408,7 +408,7 @@ task process_CDPH_clusters {
 		echo "$SAMPLEMETADATA_ARG"
 		
 		# microreact stuff
-		echo "--mr_metadata_columns $MICROREACT_COLUMNS_CSV
+		echo "--mr_metadata_columns $MICROREACT_COLUMNS_CSV"
 		echo "~{arg_force_mr_update}"
 		echo "~{arg_microreact}"
 		echo "~{arg_shareemail}"

--- a/split_cluster_tasks.wdl
+++ b/split_cluster_tasks.wdl
@@ -182,8 +182,7 @@ task process_CDPH_clusters {
 		File? cluster_matrices_randomIDs_tarball
 		File? cluster_subtrees_randomIDs_tarball
 
-		# these need to also be in your template JSON, or else they won't show up in the default MR view
-		String microreact_metadata_columns = "Epi_Duplication,Year_Collected,Patient_County,State,Country,Latitude,Longitude,Submitter_Facility,Submitter_Facility_Sample_ID,Sequencing_Facility"
+		Array[String]? microreact_metadata_columns
 
 		Boolean upload_clusters_to_microreact  = true
 		Boolean no_dropped_sample_failsafe     = false
@@ -229,10 +228,15 @@ task process_CDPH_clusters {
 	String arg_disable_dropped_sample_failsafe = if no_dropped_sample_failsafe then "--no_dropped_sample_failsafe" else ""
 	String arg_force_mr_update = if force_microreact_update then "--force_mr_update" else ""
 	String arg_verbose = if verbose then "--verbose" else ""
+
+	# naturally, this doesn't work on Cromwell
+	#String? microreact_columns_csv = if defined(microreact_metadata_columns) then sep(",", microreact_metadata_columns) else ""
 	
 	command <<<
 		set -eux pipefail
 		echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting task"
+
+		MICROREACT_COLUMNS_CSV=~{sep="," microreact_metadata_columns}
 			
 		# validate inputs
 		if [[ "~{upload_clusters_to_microreact}" = "true" ]]
@@ -404,7 +408,7 @@ task process_CDPH_clusters {
 		echo "$SAMPLEMETADATA_ARG"
 		
 		# microreact stuff
-		echo "--mr_metadata_columns ~{microreact_metadata_columns}"
+		echo "--mr_metadata_columns $MICROREACT_COLUMNS_CSV
 		echo "~{arg_force_mr_update}"
 		echo "~{arg_microreact}"
 		echo "~{arg_shareemail}"
@@ -428,7 +432,7 @@ task process_CDPH_clusters {
 			~{arg_verbose} \
 			$PERSISTENTIDS_ARG $PERSISTENTMETA_ARG \
 			$SAMPLEMETADATA_ARG \
-			--mr_metadata_columns ~{microreact_metadata_columns} \
+			--mr_metadata_columns $MICROREACT_COLUMNS_CSV \
 			~{arg_force_mr_update} \
 			~{arg_microreact} \
 			~{arg_shareemail} \

--- a/tree_nine.wdl
+++ b/tree_nine.wdl
@@ -52,7 +52,7 @@ workflow Tree_Nine {
 		File? microreact_decimated_template_json
 		File? microreact_key
 		File? microreact_update_template_json
-		Array[String] microreact_metadata_columns = ["Epi_Duplication","Year_Collected","Patient_County","State","Country","Lineage_TBProf","Resistance_TBProf","Submitter_Facility","Submitter_Facility_Sample_ID","Sequencing_Facility","Latitude","Longitude"]
+		Array[String]? microreact_metadata_columns = ["Epi_Duplication","Year_Collected","Patient_County","State","Country","Lineage_TBProf","Resistance_TBProf","Submitter_Facility","Submitter_Facility_Sample_ID","Sequencing_Facility","Latitude","Longitude"]
 		Array[Pair[String, String]]? microreact_metadata_column_renames = [("tbd_strain_per_tbprof", "Lineage_TBProf"), ("tbd_resistance", "Resistance_TBProf")]
 
 		# non-exclusive ways of sharing your microreact projects
@@ -113,9 +113,13 @@ workflow Tree_Nine {
 	}
 
 	if (defined(sample_metadata_tsv)) {
+
+		# Surely if you reference an optional value within a defined() block, you can input it as a non-optional, right?
+		# Not so! You will see here (and elsewhere) bogus select_first() fallbacks because of this quirk of WDL.
+
 		call processing.process_metadata_table as process_metadata {
 			input:
-				table = sample_metadata_tsv,
+				table = select_first([sample_metadata_tsv, diffs[0]]),
 				desired_columns = microreact_metadata_columns,
 				column_renames = microreact_metadata_column_renames,
 				strict = strictly_check_metadata
@@ -312,8 +316,7 @@ workflow Tree_Nine {
 		# in non-error cases (at least, this is the case with how we call the task here in Tree Nine)
 		# so it will never actually fall back on optimized_or_raw_tree -- and if it does error, the entire
 		# pipeline crashes so what happens here is moot.
-		File coerced_cluster_json = select_first([cluster.final_cluster_information_json, optimized_or_raw_tree])
-		File coerced_unclustered_txt = select_first([cluster.unclustered_samples, optimized_or_raw_tree])
+		File coerced_unclustered_txt = select_first([find_clusters.unclustered_samples, optimized_or_raw_tree])
 
 		if (defined(listener_bucket)) {
 			# More coercion workarounds here, this one is even sillier because we're in a defined() block, alas
@@ -322,7 +325,7 @@ workflow Tree_Nine {
 			call dropkick.Dropkick_Curl as upload_cluster_json {
 				input:
 					destination_bucket = coerced_destination_bucket,
-					files_to_upload = [coerced_cluster_json]
+					files_to_upload = [process_clusters.final_cluster_information_json]
 			}
 
 			call dropkick.Dropkick_Curl as upload_unclustered_txt {
@@ -334,10 +337,10 @@ workflow Tree_Nine {
 
 		if (defined(microreact_share_team)) {
 			if (defined(microreact_key)) {
-				if (defined(cluster.updated_mr_URIs_file)) { # must explictly check as it could be undefined if nothing got updated 
+				if (defined(process_clusters.updated_mr_URIs_file)) { # must explictly check as it could be undefined if nothing got updated 
 					File coerced_microeract_key = select_first([microreact_key, optimized_or_raw_tree])
 					String coerced_microreact_share_team = select_first([microreact_share_team, "nonsense fallback value"])
-					File coerced_updated_mr_URIs_file = select_first([cluster.updated_mr_URIs_file, optimized_or_raw_tree])
+					File coerced_updated_mr_URIs_file = select_first([process_clusters.updated_mr_URIs_file, optimized_or_raw_tree])
 					call share_projects_with_team_via_file.Microreact_Share_Projects_With_Team {
 						input:
 							token = coerced_microeract_key,
@@ -352,7 +355,7 @@ workflow Tree_Nine {
 			input:
 				input_mat = final_maximal_output_tree,
 				outfile_nextstrain = outfile_nextstrain_tree,
-				one_metadata_file = cluster.samp_cluster_ten
+				one_metadata_file = process_clusters.samp_cluster_ten
 		}
 	}
 
@@ -410,9 +413,9 @@ workflow Tree_Nine {
 		# if you want to do persistent clustering in the future, you need all five of these files
 		File updated_diff_file = cat_diff_files.outfile
 		File updated_diff_contents = samples_considered_for_clustering
-		File? updated_persistent_ids = cluster.new_persistent_ids
-		File? updated_persistent_meta = cluster.new_persistent_meta
-		File? updated_cluster_information_json = cluster.final_cluster_information_json
+		File? updated_persistent_ids = process_clusters.new_persistent_ids
+		File? updated_persistent_meta = process_clusters.new_persistent_meta
+		File? updated_cluster_information_json = process_clusters.final_cluster_information_json
 
 		#### "stats for the nerds" section, most users don't need these but they're good context ####
 

--- a/tree_nine.wdl
+++ b/tree_nine.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/aofarrel/SRANWRP/metadata-table-processer/tasks/processing_tasks.wdl" as processing
+import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.2.0/tasks/processing_tasks.wdl" as processing
 import "https://raw.githubusercontent.com/aofarrel/dropkick/1.1.0/dropkick.wdl" as dropkick
 import "https://raw.githubusercontent.com/aofarrel/microreact_WDLs/1.0.0/share_projects_with_team_via_file.wdl"
 import "./matutils_and_friends.wdl" as matWDLlib
@@ -112,6 +112,14 @@ workflow Tree_Nine {
 		upload_clusters_to_microreact: "If you know, you know"
 	}
 
+	# For TBProfiler lineage handling (if in microreact_metadata_column_renames, use the post-rename name)
+	String replace_values_in_this_column = "Lineage_TBProf"
+	Array[Pair[String, String]] value_replacements_1 = [("La1", "M. bovis (La1)"), ("La1.1", "M. bovis (La1.1)")]
+	Array[Pair[String, String]] value_replacements_2 = [("La1.2", "M. bovis not-BCG-but-BCG-like (La1.2; note TBProfiler can call BCG specifically as La1.2.BCG but did not)"), ("La1.2.BCG", "M. bovis BCG (La1.2.BCG)")]
+	Array[Pair[String, String]] value_replacements_3 = [("La1.3", "M. bovis (La1.3)"), ("La1.4", "M. bovis (La1.4)"), ("La1.5", "M. bovis (La1.5)"), ("La1.6", "M. bovis (La1.6)")]
+	Array[Pair[String, String]] value_replacements_4 = [("La1.7", "M. bovis (La1.7)"), ("La1.7.1", "M. bovis (La1.7.1)"), ("La1.8.1", "M. bovis (La1.8.1)"), ("La1.8.2", "M. bovis (La1.8.2)"), ("La2", "M. caprae (La2)"), ("La3", "M. orygis (La3)")]
+	Array[Pair[String, String]] value_replacements = flatten([value_replacements_1, value_replacements_2, value_replacements_3, value_replacements_4])
+
 	if (defined(sample_metadata_tsv)) {
 
 		# Surely if you reference an optional value within a defined() block, you can input it as a non-optional, right?
@@ -122,7 +130,9 @@ workflow Tree_Nine {
 				table = select_first([sample_metadata_tsv, diffs[0]]),
 				desired_columns = microreact_metadata_columns,
 				column_renames = microreact_metadata_column_renames,
-				strict = strictly_check_metadata
+				strict = strictly_check_metadata,
+				replace_values_in_this_column = replace_values_in_this_column,
+				value_replacements = value_replacements
 		}
 	}
 

--- a/tree_nine.wdl
+++ b/tree_nine.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.30/tasks/processing_tasks.wdl" as processing
+import "https://raw.githubusercontent.com/aofarrel/SRANWRP/metadata-table-processer/tasks/processing_tasks.wdl" as processing
 import "https://raw.githubusercontent.com/aofarrel/dropkick/1.1.0/dropkick.wdl" as dropkick
 import "https://raw.githubusercontent.com/aofarrel/microreact_WDLs/1.0.0/share_projects_with_team_via_file.wdl"
 import "./matutils_and_friends.wdl" as matWDLlib
@@ -39,6 +39,7 @@ workflow Tree_Nine {
 
 		# metadata file; expected to be pulled via the FISS API but not strictly required
 		File? sample_metadata_tsv
+		Boolean strictly_check_metadata = true
 
 		# if you are running with persistent clusters, both of these must be filled in
 		# if you are identifying clusters ad-hoc, both of these must be undefined
@@ -51,7 +52,8 @@ workflow Tree_Nine {
 		File? microreact_decimated_template_json
 		File? microreact_key
 		File? microreact_update_template_json
-		String? microreact_metadata_columns_comma_delimited  # ideally should match at least some columns in sample_metadata_tsv
+		Array[String] microreact_metadata_columns = ["Epi_Duplication","Year_Collected","Patient_County","State","Country","Lineage_TBProf","Resistance_TBProf","Submitter_Facility","Submitter_Facility_Sample_ID","Sequencing_Facility","Latitude","Longitude"]
+		Array[Pair[String, String]]? microreact_metadata_column_renames = [("tbd_strain_per_tbprof", "Lineage_TBProf"), ("tbd_resistance", "Resistance_TBProf")]
 
 		# non-exclusive ways of sharing your microreact projects
 		String? microreact_share_email
@@ -108,6 +110,16 @@ workflow Tree_Nine {
 		out_prefix: "Prefix for all output files"
 		
 		upload_clusters_to_microreact: "If you know, you know"
+	}
+
+	if (defined(sample_metadata_tsv)) {
+		call processing.process_metadata_table as process_metadata {
+			input:
+				table = sample_metadata_tsv,
+				desired_columns = microreact_metadata_columns,
+				column_renames = microreact_metadata_column_renames,
+				strict = strictly_check_metadata
+		}
 	}
 
 	call processing.cat_files as cat_diff_files {
@@ -241,26 +253,26 @@ workflow Tree_Nine {
 	}
 
 	if (identify_clusters) {
-		call matWDLlib.cluster_CDPH_method as cluster {
-			input:
-				shareemail = microreact_share_email,
-				input_mat_with_new_samples = final_maximal_output_tree,
-				special_samples = samples_considered_for_clustering,
-				combined_diff_file = cat_diff_files.outfile,
-				only_matrix_special_samples = !(cluster_entire_tree),
-				persistent_ids = persistent_cluster_ids,
-				persistent_cluster_meta = persistent_cluster_meta,
-				microreact_key = microreact_key,
-				microreact_update_template_json = microreact_update_template_json,
-				microreact_blank_template_json = microreact_blank_template_json,
-				microreact_decimated_template_json = microreact_decimated_template_json,
-				persistent_denylist = persistent_denylist,
-				upload_clusters_to_microreact = upload_clusters_to_microreact,
-				datestamp = cat_diff_files.today,
-				sample_metadata_tsv = sample_metadata_tsv,
-				microreact_metadata_columns = microreact_metadata_columns_comma_delimited,
-				override_latest_samples_tsv = DEBUG_override_latest_samples
-		}
+		#call matWDLlib.cluster_CDPH_method as cluster {
+		#	input:
+		#		shareemail = microreact_share_email,
+		#		input_mat_with_new_samples = final_maximal_output_tree,
+		#		special_samples = samples_considered_for_clustering,
+		#		combined_diff_file = cat_diff_files.outfile,
+		#		only_matrix_special_samples = !(cluster_entire_tree),
+		#		persistent_ids = persistent_cluster_ids,
+		#		persistent_cluster_meta = persistent_cluster_meta,
+		#		microreact_key = microreact_key,
+		#		microreact_update_template_json = microreact_update_template_json,
+		#		microreact_blank_template_json = microreact_blank_template_json,
+		#		microreact_decimated_template_json = microreact_decimated_template_json,
+		#		persistent_denylist = persistent_denylist,
+		#		upload_clusters_to_microreact = upload_clusters_to_microreact,
+		#		datestamp = cat_diff_files.today,
+		#		sample_metadata_tsv = sample_metadata_tsv,
+		#		microreact_metadata_columns = microreact_metadata_columns_comma_delimited,
+		#		override_latest_samples_tsv = DEBUG_override_latest_samples
+		#}
 		if (!defined(DEBUG_override_latest_samples)) {
 			call clusterlib.find_CDPH_clusters as find_clusters {
 				input:
@@ -287,8 +299,8 @@ workflow Tree_Nine {
 				persistent_denylist = persistent_denylist,
 				upload_clusters_to_microreact = upload_clusters_to_microreact,
 				datestamp = cat_diff_files.today,
-				sample_metadata_tsv = sample_metadata_tsv,
-				microreact_metadata_columns = microreact_metadata_columns_comma_delimited,
+				sample_metadata_tsv = process_metadata.processed_metadata_table,
+				microreact_metadata_columns = microreact_metadata_columns,
 				latest_samples_tsv = select_first([find_clusters.latest_samples_tsv, DEBUG_override_latest_samples]),
 				latest_clusters_tsv = select_first([find_clusters.latest_clusters_tsv, DEBUG_override_latest_clusters]),
 				cluster_matrices_randomIDs_tarball = find_clusters.cluster_matrices_randomIDs,


### PR DESCRIPTION
* Loosens the JSON template schema for Microreact -- no longer need to edit the template file itself
* Improves Microreact metadata handling
* Metadata table columns can be modified on the fly
* Metadata table can have one of its column values replaced on the fly (currently used for animal-adapted TB)
* Mass rename now handles decimated clusters more explicitly (they didn't cause errors but this is safer)
* Output decimated clusters as a file
* Fallback in case cluster-samp files ever throw a polars compute error
* Comment out old non-split call to cluster function and fix some lingering remnants 